### PR TITLE
chore: relock against the live releases

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -3,9 +3,6 @@
   "specifiers": {
     "jsr:@hiisi/flash-freeze@0.1": "0.1.1",
     "jsr:@hiisi/viola@0.3": "0.3.0",
-    "jsr:@std/assert@1": "1.0.19",
-    "jsr:@std/internal@^1.0.12": "1.0.14",
-    "npm:tree-sitter-bash@0.23.3": "0.23.3",
     "npm:web-tree-sitter@0.22.6": "0.22.6"
   },
   "jsr": {
@@ -18,33 +15,9 @@
         "jsr:@hiisi/flash-freeze",
         "npm:web-tree-sitter"
       ]
-    },
-    "@std/assert@1.0.19": {
-      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
-      "dependencies": [
-        "jsr:@std/internal"
-      ]
-    },
-    "@std/internal@1.0.14": {
-      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
     }
   },
   "npm": {
-    "node-addon-api@8.9.2": {
-      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg=="
-    },
-    "node-gyp-build@4.8.4": {
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "bin": true
-    },
-    "tree-sitter-bash@0.23.3": {
-      "integrity": "sha512-36cg/GQ2YmIbeiBeqeuh4fBJ6i4kgVouDaqTxqih5ysPag+zHufyIaxMOFeM8CeplwAK/Luj1o5XHqgdAfoCZg==",
-      "dependencies": [
-        "node-addon-api",
-        "node-gyp-build"
-      ],
-      "scripts": true
-    },
     "web-tree-sitter@0.22.6": {
       "integrity": "sha512-hS87TH71Zd6mGAmYCvlgxeGDjqd9GTeqXNqTT+u0Gs51uIozNIaaq/kUAbV/Zf56jb2ZOyG8BxZs2GG9wbLi6Q=="
     }


### PR DESCRIPTION
The lock was pinned against prereleases that are now yanked, so it resolved to versions nobody can install. Regenerated against what is actually live.

## Sanity

`deno install` completes, which it would not while the old pins were in there.