### PR TITLE
chore: relock in full, against what the registry actually serves

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,13 @@
   "specifiers": {
     "jsr:@hiisi/flash-freeze@0.1": "0.1.1",
     "jsr:@hiisi/viola@0.3": "0.3.0",
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/fs@1": "1.0.24",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/path@1": "1.1.6",
+    "jsr:@std/path@^1.1.5": "1.1.6",
+    "npm:tree-sitter-bash@0.23.3": "0.23.3",
     "npm:web-tree-sitter@0.22.6": "0.22.6"
   },
   "jsr": {
@@ -13,11 +20,49 @@
       "integrity": "c15f41be2c3e4054b433caa7ea3f366d5baa10b3dc8af4249b6569296c57a19e",
       "dependencies": [
         "jsr:@hiisi/flash-freeze",
+        "jsr:@std/fs",
+        "jsr:@std/path@1",
         "npm:web-tree-sitter"
+      ]
+    },
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/fs@1.0.24": {
+      "integrity": "f3061b45b81673a2bece689da041df32d174be064c89eb6397fb5718d3fb7877",
+      "dependencies": [
+        "jsr:@std/path@^1.1.5"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    },
+    "@std/path@1.1.6": {
+      "integrity": "c68485c2a4dfbb5ae3cc74fae4e8c4e5d874cf8a8ed12927917235c758b46cbe",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.14"
       ]
     }
   },
   "npm": {
+    "node-addon-api@8.9.2": {
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg=="
+    },
+    "node-gyp-build@4.8.4": {
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "bin": true
+    },
+    "tree-sitter-bash@0.23.3": {
+      "integrity": "sha512-36cg/GQ2YmIbeiBeqeuh4fBJ6i4kgVouDaqTxqih5ysPag+zHufyIaxMOFeM8CeplwAK/Luj1o5XHqgdAfoCZg==",
+      "dependencies": [
+        "node-addon-api",
+        "node-gyp-build"
+      ],
+      "scripts": true
+    },
     "web-tree-sitter@0.22.6": {
       "integrity": "sha512-hS87TH71Zd6mGAmYCvlgxeGDjqd9GTeqXNqTT+u0Gs51uIozNIaaq/kUAbV/Zf56jb2ZOyG8BxZs2GG9wbLi6Q=="
     }


### PR DESCRIPTION
The lock was resolving against prereleases that are yanked now, so it named versions nobody can install. Regenerated with a plain `deno install` so it covers the whole manifest rather than only what one entry point reaches.

## Sanity

`deno install` completes and the lock names only live versions, which is the one thing about a lock that can actually stop a consumer.