### PR TITLE
chore: bump off a version the registry already holds

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiisi/viola-grammar-bash",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Bash and shell script grammar package for the Viola convention linter.",
   "exports": {
     ".": "./mod.ts"


### PR DESCRIPTION
The working tree sat on 0.3.0, which is already published, so nothing here could have been released without a bump. Smallest legal step from what is live.

## Sanity

Only the version field moves.