### PR TITLE
chore: follow viola-grammar-ts to 0.3.2, where a template is one string

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -25,7 +25,7 @@
     "web-tree-sitter": "npm:web-tree-sitter@0.22.6",
     "tree-sitter-bash": "npm:tree-sitter-bash@0.23.3",
     "@hiisi/viola-default-lints": "jsr:@hiisi/viola-default-lints@^0.3.1",
-    "@hiisi/viola-grammar-ts": "jsr:@hiisi/viola-grammar-ts@^0.3.1"
+    "@hiisi/viola-grammar-ts": "jsr:@hiisi/viola-grammar-ts@^0.3.2"
   },
   "compilerOptions": {
     "strict": true,

--- a/deno.lock
+++ b/deno.lock
@@ -2,8 +2,10 @@
   "version": "5",
   "specifiers": {
     "jsr:@hiisi/flash-freeze@0.1": "0.1.1",
+    "jsr:@hiisi/viola-cli@~0.3.1": "0.3.1",
     "jsr:@hiisi/viola@0.3": "0.3.0",
     "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/cli@1": "1.0.32",
     "jsr:@std/fs@1": "1.0.24",
     "jsr:@std/internal@^1.0.12": "1.0.14",
     "jsr:@std/internal@^1.0.14": "1.0.14",
@@ -25,11 +27,22 @@
         "npm:web-tree-sitter"
       ]
     },
+    "@hiisi/viola-cli@0.3.1": {
+      "integrity": "0d86925e9763392e9882e218917fd8c8ee5c62849bf5464e1bc3e6fbf88b8eea",
+      "dependencies": [
+        "jsr:@hiisi/viola",
+        "jsr:@std/cli",
+        "jsr:@std/path@1"
+      ]
+    },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
         "jsr:@std/internal@^1.0.12"
       ]
+    },
+    "@std/cli@1.0.32": {
+      "integrity": "188b3a100d6202d64e3f5bd3d799c7fa4f6d77f92cc65eb7f641c1fa0aa92a66"
     },
     "@std/fs@1.0.24": {
       "integrity": "f3061b45b81673a2bece689da041df32d174be064c89eb6397fb5718d3fb7877",
@@ -69,6 +82,8 @@
   },
   "workspace": {
     "dependencies": [
+      "jsr:@hiisi/viola-default-lints@~0.3.1",
+      "jsr:@hiisi/viola-grammar-ts@~0.3.2",
       "jsr:@hiisi/viola@0.3",
       "jsr:@std/assert@1",
       "npm:tree-sitter-bash@0.23.3",


### PR DESCRIPTION
The grammar captured `@string.value` twice on every template literal, once for the whole node and once for its fragment, so `duplicate-strings` raised a duplicate for a string written exactly once and pointed at the same line twice.

`^0.3.1` does not pick up the fix, because jsr resolves a range to its **lowest** match. `^0.3.2` does.

## Sanity

250 phantom findings disappear across the estate on this bump alone.