### PR TITLE
fix: the linter is not a dependency of the thing it lints

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -23,9 +23,7 @@
     "@hiisi/viola/data": "jsr:@hiisi/viola@^0.3.0/data",
     "@std/assert": "jsr:@std/assert@^1",
     "web-tree-sitter": "npm:web-tree-sitter@0.22.6",
-    "tree-sitter-bash": "npm:tree-sitter-bash@0.23.3",
-    "@hiisi/viola-default-lints": "jsr:@hiisi/viola-default-lints@^0.3.1",
-    "@hiisi/viola-grammar-ts": "jsr:@hiisi/viola-grammar-ts@^0.3.2"
+    "tree-sitter-bash": "npm:tree-sitter-bash@0.23.3"
   },
   "compilerOptions": {
     "strict": true,

--- a/deno.lock
+++ b/deno.lock
@@ -82,8 +82,6 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@hiisi/viola-default-lints@~0.3.1",
-      "jsr:@hiisi/viola-grammar-ts@~0.3.2",
       "jsr:@hiisi/viola@0.3",
       "jsr:@std/assert@1",
       "npm:tree-sitter-bash@0.23.3",

--- a/viola.config.ts
+++ b/viola.config.ts
@@ -8,8 +8,8 @@
  * @module
  */
 
-import defaultLints from "@hiisi/viola-default-lints";
-import typescript from "@hiisi/viola-grammar-ts";
+import defaultLints from "jsr:@hiisi/viola-default-lints@^0.3.1";
+import typescript from "jsr:@hiisi/viola-grammar-ts@^0.3.2";
 import { report, viola, when } from "@hiisi/viola";
 
 export default viola()


### PR DESCRIPTION
Rolling the gate out put the viola packages into every manifest's `imports`. Only what `src/` and `mod.ts` actually import belongs there, and the rest are read by `viola.config.ts` alone, so listing them lied in the published manifest and made the estate's graph cyclic.

The publisher caught it by refusing to emit an order at all, which is what it was written to do rather than publishing in a guessed sequence.

Worth naming how the false edges looked real: every one of these packages has `@example` blocks in its doc comments that write `import defaultLints from "@hiisi/viola-default-lints"`, and a naive grep counts those as imports. Only a line that actually starts an import statement is one.

## Sanity

The graph is acyclic again and all twenty gates run.