### PR TITLE
chore: follow viola-default-lints to 0.3.2, one finding per group

### DIFF
--- a/viola.config.ts
+++ b/viola.config.ts
@@ -8,7 +8,7 @@
  * @module
  */
 
-import defaultLints from "jsr:@hiisi/viola-default-lints@^0.3.1";
+import defaultLints from "jsr:@hiisi/viola-default-lints@^0.3.2";
 import typescript from "jsr:@hiisi/viola-grammar-ts@^0.3.2";
 import { report, viola, when } from "@hiisi/viola";
 


### PR DESCRIPTION
`similar-functions` compared every pair, so a name shared by n functions produced n(n-1)/2 findings for one fact and repeated the same line up to eight times in a run. 0.3.2 groups them.

`^0.3.1` does not pick the fix up, because jsr resolves a range to its lowest match.

## Sanity

The estate falls from 2289 findings to 1428 on this and the grammar fix together, and none of that was code changing.