### PR TITLE
chore: follow viola to 0.4.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -18,14 +18,14 @@
     ]
   },
   "imports": {
-    "@hiisi/viola": "jsr:@hiisi/viola@^0.3.0",
-    "@hiisi/viola/grammars": "jsr:@hiisi/viola@^0.3.0/grammars",
-    "@hiisi/viola/data": "jsr:@hiisi/viola@^0.3.0/data",
+    "@hiisi/viola": "jsr:@hiisi/viola@^0.4.0",
+    "@hiisi/viola/grammars": "jsr:@hiisi/viola@^0.4.0/grammars",
+    "@hiisi/viola/data": "jsr:@hiisi/viola@^0.4.0/data",
     "@std/assert": "jsr:@std/assert@^1",
     "web-tree-sitter": "npm:web-tree-sitter@0.22.6",
     "tree-sitter-bash": "npm:tree-sitter-bash@0.23.3",
-    "@hiisi/viola-default-lints": "jsr:@hiisi/viola-default-lints@^0.3.2",
-    "@hiisi/viola-grammar-ts": "jsr:@hiisi/viola-grammar-ts@^0.3.2"
+    "@hiisi/viola-default-lints": "jsr:@hiisi/viola-default-lints@^0.4.0",
+    "@hiisi/viola-grammar-ts": "jsr:@hiisi/viola-grammar-ts@^0.4.0"
   },
   "compilerOptions": {
     "strict": true,

--- a/deno.lock
+++ b/deno.lock
@@ -2,7 +2,9 @@
   "version": "5",
   "specifiers": {
     "jsr:@hiisi/flash-freeze@~0.1.1": "0.1.2",
+    "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/fs@1": "1.0.24",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
     "jsr:@std/internal@^1.0.14": "1.0.14",
     "jsr:@std/path@1": "1.1.6",
     "jsr:@std/path@^1.1.5": "1.1.6",
@@ -12,6 +14,12 @@
   "jsr": {
     "@hiisi/flash-freeze@0.1.2": {
       "integrity": "0bd1f966675347f136d4eb2c1324a7d79deb54fa6ee4a73874b718883d7c25c0"
+    },
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
     },
     "@std/fs@1.0.24": {
       "integrity": "f3061b45b81673a2bece689da041df32d174be064c89eb6397fb5718d3fb7877",
@@ -25,7 +33,7 @@
     "@std/path@1.1.6": {
       "integrity": "c68485c2a4dfbb5ae3cc74fae4e8c4e5d874cf8a8ed12927917235c758b46cbe",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.14"
       ]
     }
   },

--- a/deno.lock
+++ b/deno.lock
@@ -2,9 +2,7 @@
   "version": "5",
   "specifiers": {
     "jsr:@hiisi/flash-freeze@~0.1.1": "0.1.2",
-    "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/fs@1": "1.0.24",
-    "jsr:@std/internal@^1.0.12": "1.0.14",
     "jsr:@std/internal@^1.0.14": "1.0.14",
     "jsr:@std/path@1": "1.1.6",
     "jsr:@std/path@^1.1.5": "1.1.6",
@@ -14,12 +12,6 @@
   "jsr": {
     "@hiisi/flash-freeze@0.1.2": {
       "integrity": "0bd1f966675347f136d4eb2c1324a7d79deb54fa6ee4a73874b718883d7c25c0"
-    },
-    "@std/assert@1.0.19": {
-      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
-      "dependencies": [
-        "jsr:@std/internal@^1.0.12"
-      ]
     },
     "@std/fs@1.0.24": {
       "integrity": "f3061b45b81673a2bece689da041df32d174be064c89eb6397fb5718d3fb7877",
@@ -33,7 +25,7 @@
     "@std/path@1.1.6": {
       "integrity": "c68485c2a4dfbb5ae3cc74fae4e8c4e5d874cf8a8ed12927917235c758b46cbe",
       "dependencies": [
-        "jsr:@std/internal@^1.0.14"
+        "jsr:@std/internal"
       ]
     }
   },
@@ -59,34 +51,34 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@hiisi/viola-default-lints@~0.3.2",
-      "jsr:@hiisi/viola-grammar-ts@~0.3.2",
-      "jsr:@hiisi/viola@0.3",
+      "jsr:@hiisi/viola-default-lints@0.4",
+      "jsr:@hiisi/viola-grammar-ts@0.4",
+      "jsr:@hiisi/viola@0.4",
       "jsr:@std/assert@1",
       "npm:tree-sitter-bash@0.23.3",
       "npm:web-tree-sitter@0.22.6"
     ],
     "links": {
-      "jsr:@hiisi/viola-default-lints@0.3.2": {
+      "jsr:@hiisi/viola-default-lints@0.4.0": {
         "dependencies": [
           "jsr:@hiisi/flash-freeze@0.1",
-          "jsr:@hiisi/viola-grammar-ts@~0.3.2",
-          "jsr:@hiisi/viola@0.3",
+          "jsr:@hiisi/viola-grammar-ts@0.4",
+          "jsr:@hiisi/viola@0.4",
           "jsr:@std/assert@1",
           "jsr:@std/fs@1",
           "jsr:@std/path@1"
         ]
       },
-      "jsr:@hiisi/viola-grammar-ts@0.3.2": {
+      "jsr:@hiisi/viola-grammar-ts@0.4.0": {
         "dependencies": [
-          "jsr:@hiisi/viola-default-lints@~0.3.2",
-          "jsr:@hiisi/viola@0.3",
+          "jsr:@hiisi/viola-default-lints@0.4",
+          "jsr:@hiisi/viola@0.4",
           "jsr:@std/assert@1",
           "npm:tree-sitter-typescript@0.23.2",
           "npm:web-tree-sitter@0.22.6"
         ]
       },
-      "jsr:@hiisi/viola@0.3.2": {
+      "jsr:@hiisi/viola@0.4.0": {
         "dependencies": [
           "jsr:@hiisi/flash-freeze@~0.1.1",
           "jsr:@hiisi/viola-default-lints@~0.3.2",


### PR DESCRIPTION
`gate.ts` calls `runProject`, which no viola before 0.4.0 exports. At the old pin
the local link stopped applying once viola's working copy moved, so the gate
loaded a published viola that could not run it.

## Sanity

`deno task lint` clean. viola 0.4.0 is published, so this resolves from the
registry rather than only through a local link.