### PR TITLE
chore: bump to 0.4.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiisi/viola-grammar-bash",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Bash and shell script grammar package for the Viola convention linter.",
   "exports": {
     ".": "./mod.ts"


### PR DESCRIPTION
The viola requirement moved to `^0.4.0`, which a consumer on viola 0.3.x cannot
satisfy. Their upgrade is not safe, so a patch bump would say something false.
Pre-1.0 that makes this a minor, and it is the smallest honest step.

## Sanity

`deno task lint` clean.